### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM fedora:latest
+RUN dnf update -y && dnf upgrade -y
+RUN dnf install -y just git go && git clone https://github.com/ZacharyWills/merkdir.git merkdir
+
+RUN cd /merkdir && just
+
+CMD ["/merkdir/merkdir"]


### PR DESCRIPTION
Tested with

`docker buildx build --platform=linux/amd64,linux/arm64 -t local/merkdir -f merkdir.Dockerfile .`

builds both an x86 and ARM image, can be reduced in size from the 500MB current size by copying the merkdir binary to a scratch container. 

Useful for running the Merkle tree generation over a mounted directory, and outputting to a file.
Something like:
`docker run --rm -it local/merkdir /merkdir/merkdir gen -o merkle_tree.file /directory/goes/here`